### PR TITLE
Add Enter key to submit guess

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,5 +107,11 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   };
 
+  document.getElementById("guessInput").addEventListener("keydown", function (event) {
+    if (event.key === "Enter") {
+      makeGuess();
+    }
+  });
+
   startGame();
 });


### PR DESCRIPTION
## Summary
- allow pressing `Enter` in the input field to trigger `makeGuess`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e7170697c832cb9970652755ad201